### PR TITLE
Use new jujuclient store for model info and refactor tests

### DIFF
--- a/cmd/allocate/export_test.go
+++ b/cmd/allocate/export_test.go
@@ -4,15 +4,13 @@
 package allocate
 
 import (
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"github.com/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 )
 
-var (
-	NewAPIClient = &newAPIClient
-)
-
-func APIClientFnc(api apiClient) func(*httpbakery.Client) (apiClient, error) {
-	return func(*httpbakery.Client) (apiClient, error) {
-		return api, nil
-	}
+func NewAllocateCommandForTest(api apiClient, store jujuclient.ClientStore) cmd.Command {
+	c := &allocateCommand{api: api}
+	c.SetClientStore(store)
+	return modelcmd.Wrap(c)
 }

--- a/cmd/updateallocation/export_test.go
+++ b/cmd/updateallocation/export_test.go
@@ -4,16 +4,13 @@
 package updateallocation
 
 import (
-	"gopkg.in/macaroon-bakery.v1/httpbakery"
+	"github.com/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/jujuclient"
 )
 
-var (
-	NewAPIClient = &newAPIClient
-)
-
-// APIClientFnc allow patching of the apiClient
-func APIClientFnc(api apiClient) func(*httpbakery.Client) (apiClient, error) {
-	return func(_ *httpbakery.Client) (apiClient, error) {
-		return api, nil
-	}
+func NewUpdateAllocateCommandForTest(api apiClient, store jujuclient.ClientStore) cmd.Command {
+	c := &updateAllocationCommand{api: api}
+	c.SetClientStore(store)
+	return modelcmd.Wrap(c)
 }

--- a/cmd/updateallocation/updateallocation_test.go
+++ b/cmd/updateallocation/updateallocation_test.go
@@ -4,11 +4,13 @@
 package updateallocation_test
 
 import (
+	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs/configstore"
-	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/jujuclient"
+	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/testing"
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -18,43 +20,45 @@ import (
 var _ = gc.Suite(&updateAllocationSuite{})
 
 type updateAllocationSuite struct {
-	coretesting.FakeJujuXDGDataHomeSuite
+	jujutesting.FakeHomeSuite
 	stub    *testing.Stub
 	mockAPI *mockapi
+	store   jujuclient.ClientStore
 }
 
 func (s *updateAllocationSuite) SetUpTest(c *gc.C) {
-	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	c.Log(coretesting.SingleEnvConfig)
-	store, err := configstore.Default()
-	c.Assert(err, jc.ErrorIsNil)
-	info := store.CreateInfo(coretesting.SampleModelName)
-	apiEndpoint := configstore.APIEndpoint{
-		ModelUUID: "env-uuid",
+	s.FakeHomeSuite.SetUpTest(c)
+	s.store = &jujuclienttesting.MemStore{
+		Models: map[string]*jujuclient.ControllerModels{
+			"controller": {Models: map[string]jujuclient.ModelDetails{
+				"model": jujuclient.ModelDetails{"model-uuid"},
+			}},
+		},
 	}
-	info.SetAPIEndpoint(apiEndpoint)
-	err = info.Write()
-	c.Assert(err, jc.ErrorIsNil)
 	s.stub = &testing.Stub{}
 	s.mockAPI = newMockAPI(s.stub)
-	s.PatchValue(updateallocation.NewAPIClient, updateallocation.APIClientFnc(s.mockAPI))
+}
+
+func (s *updateAllocationSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
+	updateAlloc := updateallocation.NewUpdateAllocateCommandForTest(s.mockAPI, s.store)
+	a := []string{"-m", "controller:model"}
+	a = append(a, args...)
+	return cmdtesting.RunCommand(c, updateAlloc, a...)
 }
 
 func (s *updateAllocationSuite) TestUpdateAllocation(c *gc.C) {
 	s.mockAPI.resp = "name budget set to 5"
-	set := updateallocation.NewUpdateAllocationCommand()
-	ctx, err := cmdtesting.RunCommand(c, set, "name", "5")
+	ctx, err := s.run(c, "name", "5")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), jc.DeepEquals, "name budget set to 5")
-	s.mockAPI.CheckCall(c, 0, "UpdateAllocation", "env-uuid", "name", "5")
+	s.mockAPI.CheckCall(c, 0, "UpdateAllocation", "model-uuid", "name", "5")
 }
 
 func (s *updateAllocationSuite) TestUpdateAllocationAPIError(c *gc.C) {
 	s.stub.SetErrors(errors.New("something failed"))
-	set := updateallocation.NewUpdateAllocationCommand()
-	_, err := cmdtesting.RunCommand(c, set, "name", "5")
+	_, err := s.run(c, "name", "5")
 	c.Assert(err, gc.ErrorMatches, "failed to update the allocation: something failed")
-	s.mockAPI.CheckCall(c, 0, "UpdateAllocation", "env-uuid", "name", "5")
+	s.mockAPI.CheckCall(c, 0, "UpdateAllocation", "model-uuid", "name", "5")
 }
 
 func (s *updateAllocationSuite) TestUpdateAllocationErrors(c *gc.C) {
@@ -82,8 +86,7 @@ func (s *updateAllocationSuite) TestUpdateAllocationErrors(c *gc.C) {
 	for i, test := range tests {
 		s.mockAPI.ResetCalls()
 		c.Logf("test %d: %s", i, test.about)
-		set := updateallocation.NewUpdateAllocationCommand()
-		_, err := cmdtesting.RunCommand(c, set, test.args...)
+		_, err := s.run(c, test.args...)
 		c.Check(err, gc.ErrorMatches, test.expectedError)
 		s.mockAPI.CheckNoCalls(c)
 	}


### PR DESCRIPTION
The old configstore is replaced by the jujuclient store.
Test are refactored to use the in memory store to avoid writes to disk.