### PR TITLE
cmd/allocate: Improvement on error message to make order of args obvious

### DIFF
--- a/cmd/allocate/allocate.go
+++ b/cmd/allocate/allocate.go
@@ -80,7 +80,7 @@ func (c *allocateCommand) Init(args []string) error {
 	var err error
 	c.Budget, c.Limit, err = parseBudgetWithLimit(budgetWithLimit)
 	if err != nil {
-		return err
+		return errors.Annotate(err, `expected args in the form "budget:limit [service ...]"`)
 	}
 	if c.ModelUUID == "" {
 		c.ModelUUID, err = c.modelUUID()

--- a/cmd/allocate/allocate_test.go
+++ b/cmd/allocate/allocate_test.go
@@ -105,7 +105,7 @@ func (s *allocateSuite) TestAllocateErrors(c *gc.C) {
 	}, {
 		about:         "budget without allocation limit",
 		args:          []string{"name", "db"},
-		expectedError: "invalid budget specification, expecting <budget>:<limit>",
+		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}, {
 		about:         "service not specified",
 		args:          []string{"name:100"},
@@ -113,19 +113,23 @@ func (s *allocateSuite) TestAllocateErrors(c *gc.C) {
 	}, {
 		about:         "negative allocation limit",
 		args:          []string{"name:-100", "db"},
-		expectedError: "invalid budget specification, expecting <budget>:<limit>",
+		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}, {
 		about:         "non-numeric allocation limit",
 		args:          []string{"name:abcd", "db"},
-		expectedError: "invalid budget specification, expecting <budget>:<limit>",
+		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}, {
 		about:         "empty allocation limit",
 		args:          []string{"name:", "db"},
-		expectedError: "invalid budget specification, expecting <budget>:<limit>",
+		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}, {
 		about:         "invalid model UUID",
 		args:          []string{"--model-uuid", "nope", "name:100", "db"},
 		expectedError: `model UUID "nope" not valid`,
+	}, {
+		about:         "arguments in wrong order",
+		args:          []string{"name:", "db:50"},
+		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}}
 	for i, test := range tests {
 		c.Logf("test %d: %s", i, test.about)


### PR DESCRIPTION
I'm not totally convinced this is an improvement. But I offer it up here in the name of conversation