### PR TITLE
Make juju list-<cmd> aliases for their juju <cmd>

### DIFF
--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -39,13 +39,13 @@ func RegisterAll(r commandRegister) {
 
 	}
 	register(agree.NewAgreeCommand())
+	register(listagreements.NewListAgreementsCommand())
 	register(allocate.NewAllocateCommand())
-	register(createbudget.NewCreateBudgetCommand())
 	register(listbudgets.NewListBudgetsCommand())
+	register(createbudget.NewCreateBudgetCommand())
 	register(listplans.NewListPlansCommand())
 	register(setbudget.NewSetBudgetCommand())
 	register(setplan.NewSetPlanCommand())
 	register(showbudget.NewShowBudgetCommand())
 	register(updateallocation.NewUpdateAllocationCommand())
-	register(listagreements.NewListAgreementsCommand())
 }

--- a/cmd/commands/commands_test.go
+++ b/cmd/commands/commands_test.go
@@ -33,14 +33,14 @@ func (s *commandSuite) TestRegister(c *gc.C) {
 	commands.RegisterAll(m)
 	c.Assert(m.commands, gc.DeepEquals, []string{
 		"agree",
+		"agreements",
 		"allocate",
+		"budgets",
 		"create-budget",
-		"list-budgets",
-		"list-plans",
+		"plans",
 		"set-budget",
 		"set-plan",
 		"show-budget",
 		"update-allocation",
-		"list-agreements",
 	})
 }

--- a/cmd/listagreements/listagreements.go
+++ b/cmd/listagreements/listagreements.go
@@ -28,7 +28,7 @@ type TermsServiceClient interface {
 }
 
 const listAgreementsDoc = `
-list-agreements is used to list terms the user has agreed to.
+List terms the user has agreed to.
 `
 
 // NewListAgreementsCommand returns a new command that can be
@@ -62,9 +62,10 @@ func (c *listAgreementsCommand) SetFlags(f *gnuflag.FlagSet) {
 // Info implements Command.Info.
 func (c *listAgreementsCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "list-agreements",
+		Name:    "agreements",
 		Purpose: "list user's agreements",
 		Doc:     listAgreementsDoc,
+		Aliases: []string{"list-agreements"},
 	}
 }
 

--- a/cmd/listbudgets/list-budgets.go
+++ b/cmd/listbudgets/list-budgets.go
@@ -33,15 +33,16 @@ const listBudgetsDoc = `
 List the available budgets.
 
 Example:
- juju list-budgets
+ juju budgets
 `
 
 // Info implements cmd.Command.Info.
 func (c *listBudgetsCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "list-budgets",
+		Name:    "budgets",
 		Purpose: "list budgets",
 		Doc:     listBudgetsDoc,
+		Aliases: []string{"list-budgets"},
 	}
 }
 

--- a/cmd/listplans/list_plans.go
+++ b/cmd/listplans/list_plans.go
@@ -40,7 +40,7 @@ const listPlansDoc = `
 List plans available for the specified charm.
 
 Example:
- juju list-plans cs:webapp
+ juju plans cs:webapp
 `
 
 // ListPlansCommand retrieves plans that are available for the specified charm
@@ -63,10 +63,11 @@ func NewListPlansCommand() modelcmd.CommandBase {
 // Info implements Command.Info.
 func (c *ListPlansCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "list-plans",
+		Name:    "plans",
 		Args:    "",
 		Purpose: "list plans",
 		Doc:     listPlansDoc,
+		Aliases: []string{"list-plans"},
 	}
 }
 


### PR DESCRIPTION
Part fix for lp#1585005, this commit updates agreements, budgets
and plans commands.

QA steps:

  * `juju help commands | grep list-` should show list-<cmd> as an
     alias to <cmd>