### PR TITLE
Update command help text for romulus commands

### DIFF
--- a/cmd/agree/agree.go
+++ b/cmd/agree/agree.go
@@ -33,14 +33,15 @@ view the terms and agree to them. Then the charm may be deployed.
 Once you have agreed to terms, you will not be prompted to view them again.
 
 Examples:
+    # Displays terms for somePlan revision 1 and prompts for agreement.
+    juju agree somePlan/1
 
- juju agree somePlan/1
-     Displays terms for somePlan revision 1 and prompts for agreement.
- juju agree somePlan/1 otherPlan/2
-     Displays the terms for revision 1 of somePlan, revision 2 of otherPlan,
-     and prompts for agreement.
- juju agree somePlan/1 otherPlan/2 --yes
-     Agrees to the terms without prompting.
+    # Displays the terms for revision 1 of somePlan, revision 2 of otherPlan,
+    # and prompts for agreement.
+    juju agree somePlan/1 otherPlan/2
+
+    # Agrees to the terms without prompting.
+    juju agree somePlan/1 otherPlan/2 --yes
 `
 
 // NewAgreeCommand returns a new command that can be
@@ -66,7 +67,7 @@ type agreeCommand struct {
 
 // SetFlags implements Command.SetFlags.
 func (c *agreeCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.SkipTermContent, "yes", false, "agree to terms non interactively")
+	f.BoolVar(&c.SkipTermContent, "yes", false, "Agree to terms non interactively")
 	c.out.AddFlags(f, "json", cmd.DefaultFormatters)
 }
 
@@ -75,7 +76,7 @@ func (c *agreeCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "agree",
 		Args:    "<term>",
-		Purpose: "agree to terms",
+		Purpose: "Agree to terms.",
 		Doc:     agreeDoc,
 	}
 }

--- a/cmd/allocate/allocate.go
+++ b/cmd/allocate/allocate.go
@@ -36,37 +36,33 @@ func NewAllocateCommand() modelcmd.ModelCommand {
 }
 
 const doc = `
-Allocate budget for the specified services, replacing any prior allocations
-made for the specified services.
+Allocate budget for the specified applications, replacing any prior allocations
+made for the specified applications.
 
-Usage:
+Examples:
+    # Assigns application "db" to an allocation on budget "somebudget" with
+    # the limit "42".
+    juju allocate somebudget:42 db
 
- juju allocate <budget>:<value> <service> [<service2> ...]
+    # Application names assume the current selected model, unless otherwise
+    # specified with:
+    juju allocate -m [<controller name:]<model name> ...
 
-Example:
-
- juju allocate somebudget:42 db
-     Assigns application "db" to an allocation on budget "somebudget" with the limit "42".
-
-Service names assume the current selected model, unless otherwise specified with:
-
- juju allocate -m [<controller name:]<model name> ...
-
-Models may also be referenced by UUID when necessary:
-
- juju allocate --model-uuid <uuid> ...
+    # Models may also be referenced by UUID when necessary:
+     juju allocate --model-uuid <uuid> ...
 `
 
 // SetFlags implements cmd.Command.SetFlags.
 func (c *allocateCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.ModelUUID, "model-uuid", "", "Model UUID of allocation.")
+	f.StringVar(&c.ModelUUID, "model-uuid", "", "Model UUID of allocation")
 }
 
 // Info implements cmd.Command.Info.
 func (c *allocateCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "allocate",
-		Purpose: "allocate budget to services",
+		Args:    "<budget>:<value> <application> [<application2> ...]",
+		Purpose: "Allocate budget to applications.",
 		Doc:     doc,
 	}
 }
@@ -74,13 +70,13 @@ func (c *allocateCommand) Info() *cmd.Info {
 // Init implements cmd.Command.Init.
 func (c *allocateCommand) Init(args []string) error {
 	if len(args) < 2 {
-		return errors.New("budget and service name required")
+		return errors.New("budget and application name required")
 	}
 	budgetWithLimit := args[0]
 	var err error
 	c.Budget, c.Limit, err = parseBudgetWithLimit(budgetWithLimit)
 	if err != nil {
-		return errors.Annotate(err, `expected args in the form "budget:limit [service ...]"`)
+		return errors.Annotate(err, `expected args in the form "budget:limit [application ...]"`)
 	}
 	if c.ModelUUID == "" {
 		c.ModelUUID, err = c.modelUUID()

--- a/cmd/allocate/allocate_test.go
+++ b/cmd/allocate/allocate_test.go
@@ -101,27 +101,27 @@ func (s *allocateSuite) TestAllocateErrors(c *gc.C) {
 	}{{
 		about:         "no args",
 		args:          []string{},
-		expectedError: "budget and service name required",
+		expectedError: "budget and application name required",
 	}, {
 		about:         "budget without allocation limit",
 		args:          []string{"name", "db"},
-		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
+		expectedError: `expected args in the form "budget:limit \[application ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}, {
-		about:         "service not specified",
+		about:         "application not specified",
 		args:          []string{"name:100"},
-		expectedError: "budget and service name required",
+		expectedError: "budget and application name required",
 	}, {
 		about:         "negative allocation limit",
 		args:          []string{"name:-100", "db"},
-		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
+		expectedError: `expected args in the form "budget:limit \[application ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}, {
 		about:         "non-numeric allocation limit",
 		args:          []string{"name:abcd", "db"},
-		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
+		expectedError: `expected args in the form "budget:limit \[application ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}, {
 		about:         "empty allocation limit",
 		args:          []string{"name:", "db"},
-		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
+		expectedError: `expected args in the form "budget:limit \[application ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}, {
 		about:         "invalid model UUID",
 		args:          []string{"--model-uuid", "nope", "name:100", "db"},
@@ -129,7 +129,7 @@ func (s *allocateSuite) TestAllocateErrors(c *gc.C) {
 	}, {
 		about:         "arguments in wrong order",
 		args:          []string{"name:", "db:50"},
-		expectedError: `expected args in the form "budget:limit \[service ...\]": invalid budget specification, expecting <budget>:<limit>`,
+		expectedError: `expected args in the form "budget:limit \[application ...\]": invalid budget specification, expecting <budget>:<limit>`,
 	}}
 	for i, test := range tests {
 		c.Logf("test %d: %s", i, test.about)

--- a/cmd/createbudget/createbudget.go
+++ b/cmd/createbudget/createbudget.go
@@ -29,16 +29,16 @@ func NewCreateBudgetCommand() cmd.Command {
 const doc = `
 Create a new budget with monthly limit.
 
-Example:
- juju create-budget qa 42
-     Creates a budget named 'qa' with a limit of 42.
+Examples:
+    # Creates a budget named 'qa' with a limit of 42.
+    juju create-budget qa 42
 `
 
 // Info implements cmd.Command.Info.
 func (c *createBudgetCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "create-budget",
-		Purpose: "create a new budget",
+		Purpose: "Create a new budget.",
 		Doc:     doc,
 	}
 }

--- a/cmd/listagreements/listagreements.go
+++ b/cmd/listagreements/listagreements.go
@@ -63,7 +63,7 @@ func (c *listAgreementsCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *listAgreementsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "agreements",
-		Purpose: "list user's agreements",
+		Purpose: "List user's agreements.",
 		Doc:     listAgreementsDoc,
 		Aliases: []string{"list-agreements"},
 	}

--- a/cmd/listbudgets/list-budgets.go
+++ b/cmd/listbudgets/list-budgets.go
@@ -32,15 +32,15 @@ type listBudgetsCommand struct {
 const listBudgetsDoc = `
 List the available budgets.
 
-Example:
- juju budgets
+Examples:
+    juju budgets
 `
 
 // Info implements cmd.Command.Info.
 func (c *listBudgetsCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "budgets",
-		Purpose: "list budgets",
+		Purpose: "List budgets.",
 		Doc:     listBudgetsDoc,
 		Aliases: []string{"list-budgets"},
 	}

--- a/cmd/listplans/list_plans.go
+++ b/cmd/listplans/list_plans.go
@@ -39,8 +39,8 @@ var newClient = func(client *httpbakery.Client) (apiClient, error) {
 const listPlansDoc = `
 List plans available for the specified charm.
 
-Example:
- juju plans cs:webapp
+Examples:
+    juju plans cs:webapp
 `
 
 // ListPlansCommand retrieves plans that are available for the specified charm
@@ -65,7 +65,7 @@ func (c *ListPlansCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "plans",
 		Args:    "",
-		Purpose: "list plans",
+		Purpose: "List plans.",
 		Doc:     listPlansDoc,
 		Aliases: []string{"list-plans"},
 	}

--- a/cmd/setbudget/setbudget.go
+++ b/cmd/setbudget/setbudget.go
@@ -29,16 +29,17 @@ func NewSetBudgetCommand() cmd.Command {
 const doc = `
 Set the monthly budget limit.
 
-Example:
- juju set-budget personal 96
-     Sets the monthly limit for budget named 'personal' to 96.
+Examples:
+    # Sets the monthly limit for budget named 'personal' to 96.
+    juju set-budget personal 96
 `
 
 // Info implements cmd.Command.Info.
 func (c *setBudgetCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "set-budget",
-		Purpose: "set the budget limit",
+		Args:    "<budget name> <value>",
+		Purpose: "Set the budget limit.",
 		Doc:     doc,
 	}
 }

--- a/cmd/setplan/set_plan.go
+++ b/cmd/setplan/set_plan.go
@@ -51,19 +51,15 @@ func (c *setPlanCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "set-plan",
 		Args:    "<application name> <plan>",
-		Purpose: "set the plan for an application",
+		Purpose: "Set the plan for an application.",
 		Doc: `
 Set the plan for the deployed application, effective immediately.
 
-The specified plan name must be a valid plan that is offered for this particular charm. Use "juju list-plans <charm>" for more information.
-	
-Usage:
+The specified plan name must be a valid plan that is offered for this
+particular charm. Use "juju list-plans <charm>" for more information.
 
- juju set-plan [options] <application name> <plan name>
-
-Example:
-
- juju set-plan myapp example/uptime
+Examples:
+    juju set-plan myapp example/uptime
 `,
 	}
 }

--- a/cmd/showbudget/show_budget.go
+++ b/cmd/showbudget/show_budget.go
@@ -39,15 +39,16 @@ type showBudgetCommand struct {
 const showBudgetDoc = `
 Display budget usage information.
 
-Example:
- juju show-budget personal
+Examples:
+    juju show-budget personal
 `
 
 // Info implements cmd.Command.Info.
 func (c *showBudgetCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "show-budget",
-		Purpose: "show budget usage",
+		Args:    "<budget>",
+		Purpose: "Show details about a budget.",
 		Doc:     showBudgetDoc,
 	}
 }

--- a/cmd/updateallocation/updateallocation.go
+++ b/cmd/updateallocation/updateallocation.go
@@ -41,18 +41,19 @@ type apiClient interface {
 }
 
 const doc = `
-Updates an existing allocation on a service.
+Updates an existing allocation on an application.
 
-Example:
- juju update-allocation wordpress 10
-     Sets the allocation for the wordpress service to 10.
+Examples:
+    # Sets the allocation for the wordpress application to 10.
+    juju update-allocation wordpress 10
 `
 
 // Info implements cmd.Command.Info.
 func (c *updateAllocationCommand) Info() *cmd.Info {
 	return &cmd.Info{
 		Name:    "update-allocation",
-		Purpose: "update an allocation",
+		Args:    "<application> <value>",
+		Purpose: "Update an allocation.",
 		Doc:     doc,
 	}
 }
@@ -60,7 +61,7 @@ func (c *updateAllocationCommand) Info() *cmd.Info {
 // Init implements cmd.Command.Init.
 func (c *updateAllocationCommand) Init(args []string) error {
 	if len(args) < 2 {
-		return errors.New("service and value required")
+		return errors.New("application and value required")
 	}
 	c.Name, c.Value = args[0], args[1]
 	if _, err := strconv.ParseInt(c.Value, 10, 32); err != nil {

--- a/cmd/updateallocation/updateallocation_test.go
+++ b/cmd/updateallocation/updateallocation_test.go
@@ -93,12 +93,12 @@ func (s *updateAllocationSuite) TestUpdateAllocationErrors(c *gc.C) {
 		{
 			about:         "value is missing",
 			args:          []string{"name"},
-			expectedError: "service and value required",
+			expectedError: "application and value required",
 		},
 		{
 			about:         "no args",
 			args:          []string{},
-			expectedError: "service and value required",
+			expectedError: "application and value required",
 		},
 	}
 	for i, test := range tests {


### PR DESCRIPTION
This PR updates the command help text to follow
the standards in github.com/juju/juju:

- Summary / Purpose begins with a capital letter
  and ends with a period
- Flag descriptions begin with a capital letter, but
  do not have a period
- Arguments are listed in the 'Args' field of the
  cmd.Info struct.
- Examples are under an 'Examples' header, even if
  only one exists and are indented 4 spaces.
- 'Services' are now 'Applications'

There were a few other minor cleanups for clarity.