### PR TITLE
Forward-compatible unmarshaling of Juju 2.0 field naming conv.

### DIFF
--- a/wireformat/budget/entities_test.go
+++ b/wireformat/budget/entities_test.go
@@ -1,9 +1,11 @@
 package budget_test
 
 import (
+	"encoding/json"
 	"sort"
 	"testing"
 
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/romulus/wireformat/budget"
@@ -102,4 +104,46 @@ func (t *BudgetSuite) TestAllocationSorting(c *gc.C) {
 
 	sort.Sort(budget.SortedAllocations(allocations))
 	c.Assert(allocations, gc.DeepEquals, expected)
+}
+
+func (t *BudgetSuite) TestUnmarshalServices(c *gc.C) {
+	data := []byte(`{
+	"owner": "bob",
+	"limit": "sky",
+	"consumed": "much",
+	"usage": "angry",
+	"model": "citizen",
+	"services": {
+		"practical": {
+			"consumed": "vivaciously"
+		}
+	}
+}`)
+	var alloc budget.Allocation
+	err := json.Unmarshal(data, &alloc)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(alloc.Model, gc.Equals, "citizen")
+	c.Assert(alloc.Services, gc.HasLen, 1)
+	c.Assert(alloc.Services["practical"].Consumed, gc.Equals, "vivaciously")
+}
+
+func (t *BudgetSuite) TestUnmarshalApplications(c *gc.C) {
+	data := []byte(`{
+	"owner": "bob",
+	"limit": "sky",
+	"consumed": "much",
+	"usage": "angry",
+	"model": "citizen",
+	"applications": {
+		"theoretical": {
+			"consumed": "voraciously"
+		}
+	}
+}`)
+	var alloc budget.Allocation
+	err := json.Unmarshal(data, &alloc)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(alloc.Model, gc.Equals, "citizen")
+	c.Assert(alloc.Services, gc.HasLen, 1)
+	c.Assert(alloc.Services["theoretical"].Consumed, gc.Equals, "voraciously")
 }

--- a/wireformat/metrics/metrics.go
+++ b/wireformat/metrics/metrics.go
@@ -6,6 +6,7 @@
 package metrics
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -21,6 +22,25 @@ type MetricBatch struct {
 	Credentials []byte    `json:"credentials"`
 }
 
+type metricBatchV1 MetricBatch
+
+// UnmarshalJSON implements a transitional json.Unmarshaler to allow
+// forward-compatible processing of fields renamed in Juju 2.0.
+func (mb *MetricBatch) UnmarshalJSON(data []byte) error {
+	v := struct {
+		metricBatchV1
+		ModelUUID string `json:"model-uuid"`
+	}{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	*mb = MetricBatch(v.metricBatchV1)
+	if mb.ModelUUID == "" {
+		mb.ModelUUID = v.ModelUUID
+	}
+	return nil
+}
+
 // Metric represents a single Metric.
 type Metric struct {
 	Key   string    `json:"key"`
@@ -33,6 +53,25 @@ type Response struct {
 	UUID           string               `json:"uuid"`
 	EnvResponses   EnvironmentResponses `json:"env-responses"`
 	NewGracePeriod time.Duration        `json:"new-grace-period"`
+}
+
+type responseV1 Response
+
+// UnmarshalJSON implements a transitional json.Unmarshaler to allow
+// forward-compatible processing of fields renamed in Juju 2.0.
+func (r *Response) UnmarshalJSON(data []byte) error {
+	v := struct {
+		responseV1
+		ModelResponses EnvironmentResponses `json:"model-responses"`
+	}{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	*r = Response(v.responseV1)
+	if r.EnvResponses == nil {
+		r.EnvResponses = v.ModelResponses
+	}
+	return nil
 }
 
 type EnvironmentResponses map[string]EnvResponse
@@ -62,7 +101,6 @@ func (e EnvironmentResponses) SetStatus(modelUUID, unitName, status, info string
 		env.UnitStatuses[unitName] = s
 	}
 	e[modelUUID] = env
-
 }
 
 // EnvResponse contains the response data relevant to a concrete environment.

--- a/wireformat/plan/entities_test.go
+++ b/wireformat/plan/entities_test.go
@@ -1,0 +1,55 @@
+package plan_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/romulus/wireformat/plan"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type planSuite struct{}
+
+var _ = gc.Suite(&planSuite{})
+
+func (t *planSuite) TestUnmarshalEnvService(c *gc.C) {
+	data := []byte(`{
+	"env-uuid": "some env",
+	"charm-url": "some charm",
+	"service-name": "some service",
+	"plan-url": "some plan"
+}`)
+	var ar plan.AuthorizationRequest
+	err := json.Unmarshal(data, &ar)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ar, gc.Equals, plan.AuthorizationRequest{
+		EnvironmentUUID: "some env",
+		CharmURL:        "some charm",
+		ServiceName:     "some service",
+		PlanURL:         "some plan",
+	})
+}
+
+func (t *planSuite) TestUnmarshalModelApplication(c *gc.C) {
+	data := []byte(`{
+	"model-uuid": "some model",
+	"charm-url": "some charm",
+	"application-name": "some application",
+	"plan-url": "some plan"
+}`)
+	var ar plan.AuthorizationRequest
+	err := json.Unmarshal(data, &ar)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ar, gc.Equals, plan.AuthorizationRequest{
+		EnvironmentUUID: "some model",
+		CharmURL:        "some charm",
+		ServiceName:     "some application",
+		PlanURL:         "some plan",
+	})
+}


### PR DESCRIPTION
Wireformat types support provisional unmarshaling of types with the "new naming"
convention in Juju 2.0:

"env", "environment" => "model"
"service" => "application"

This allows the message recipient (whether the wireformat type comes in
a request, or in repsonse to one) to understand the new names, without
breaking anything that currently works.
